### PR TITLE
Fix duplicate PwShExec function

### DIFF
--- a/wslpy/winsys.py
+++ b/wslpy/winsys.py
@@ -34,7 +34,7 @@ def PwShExec(command):
     cmd = u"powershell.exe -NoProfile -NonInteractive -Command \""+command+u"\""
     subprocess.call(cmd, shell=True)
 
-def PwShExec(command):
+def PwShCrExec(command):
     """
     Execute PowerShell Core 6 commands.
     :param command: pwsh.exe commands.


### PR DESCRIPTION
The function `PwShExec` appears in `winsys.py` twice and `PwShCrExec` from the Readme doesn't appear at all. This PR fixes this.