### PR TITLE
convert.to shouldn't suppress error

### DIFF
--- a/wslpy/convert.py
+++ b/wslpy/convert.py
@@ -68,44 +68,41 @@ def to(input, toType=PathConvType.AUTO):
     ValueError
         An error occurred when the input is invalid.
     """
-    try:
-        if re.match(r'\/mnt\/[A-Za-z]', input) is not None:  # Linux Path
-            if toType == PathConvType.AUTO:
-                return __Lin2Win__(input)
-            elif toType == PathConvType.WIN:
-                return __Lin2Win__(input)
-            elif toType == PathConvType.LINUX:
-                return input
-            elif toType == PathConvType.WINDOUBLE:
-                return __Win2Dwin__(__Lin2Win__(input))
-            else:
-                raise ValueError("ERROR: Invalid Conversion Type "+toType)
-        elif re.match(r'[A-Za-z]:\\\\', input) is not None:  # Windows Path /w Double Dashline
-            if toType == PathConvType.AUTO:
-                return __DWin2Lin__(input)
-            elif toType == PathConvType.LINUX:
-                return __DWin2Lin__(input)
-            elif toType == PathConvType.WIN:
-                return __Lin2Win__(__DWin2Lin__(input))
-            elif toType == PathConvType.WINDOUBLE:
-                return input
-            else:
-                raise ValueError("ERROR: Invalid Conversion Type "+toType)
-        elif re.match(r'[A-Za-z]:', input) is not None:  # Windows Path
-            if toType == PathConvType.AUTO:
-                return __DWin2Lin__(__Win2Dwin__(input))
-            elif toType == PathConvType.LINUX:
-                return __DWin2Lin__(__Win2Dwin__(input))
-            elif toType == PathConvType.WIN:
-                return input
-            elif toType == PathConvType.WINDOUBLE:
-                return __Win2Dwin__(input)
-            else:
-                raise ValueError("Invalid Conversion Type "+toType)
+    if re.match(r'\/mnt\/[A-Za-z]', input) is not None:  # Linux Path
+        if toType == PathConvType.AUTO:
+            return __Lin2Win__(input)
+        elif toType == PathConvType.WIN:
+            return __Lin2Win__(input)
+        elif toType == PathConvType.LINUX:
+            return input
+        elif toType == PathConvType.WINDOUBLE:
+            return __Win2Dwin__(__Lin2Win__(input))
         else:
-            raise ValueError("Invalid Path "+input)
-    except ValueError as err:
-        print(err)
+            raise ValueError("ERROR: Invalid Conversion Type "+toType)
+    elif re.match(r'[A-Za-z]:\\\\', input) is not None:  # Windows Path /w Double Dashline
+        if toType == PathConvType.AUTO:
+            return __DWin2Lin__(input)
+        elif toType == PathConvType.LINUX:
+            return __DWin2Lin__(input)
+        elif toType == PathConvType.WIN:
+            return __Lin2Win__(__DWin2Lin__(input))
+        elif toType == PathConvType.WINDOUBLE:
+            return input
+        else:
+            raise ValueError("ERROR: Invalid Conversion Type "+toType)
+    elif re.match(r'[A-Za-z]:', input) is not None:  # Windows Path
+        if toType == PathConvType.AUTO:
+            return __DWin2Lin__(__Win2Dwin__(input))
+        elif toType == PathConvType.LINUX:
+            return __DWin2Lin__(__Win2Dwin__(input))
+        elif toType == PathConvType.WIN:
+            return input
+        elif toType == PathConvType.WINDOUBLE:
+            return __Win2Dwin__(input)
+        else:
+            raise ValueError("Invalid Conversion Type "+toType)
+    else:
+        raise ValueError("Invalid Path "+input)
 
 
 def toWin(input):


### PR DESCRIPTION
Leaving the TypeError to user rather than suppressing it printing some error should be the pythonic way to do it.

I just dropped the two line, and de-tab the try-block, but git mistakenly show a lot diffs, which may mess up your line history. So i put another cleaner PR at #5. Whichever you like.

